### PR TITLE
Fix/compilation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+**/.libs/
+**/.deps/
+**/*.o
+**/*.Po
+**/*.Plo
+**/*.lo
+**/*.la
+**/.dirstamp
+
 /nbproject/private/
 /autoscan.log
 /configure.scan
@@ -20,8 +29,6 @@
 /po/POTFILES
 /missing
 /docs/
-/src/.libs/
-/src/.deps/
 /src/libtrudp.pc
 /po/Makefile.in
 /po/Makefile
@@ -37,27 +44,16 @@
 /m4/
 /tests/Makefile.in
 /tests/Makefile
-/tests/.libs/
 /tests/trudp_tst
 /examples/Makefile
 /examples/Makefile.in
 /examples/trudpcat_ev
-/examples/.libs/
 
 /config.log
 /repo/
 /Doxyfile.bak
 /trudp_0.*
 /libtrudp_0.*
-*.Po
-*.Plo
-.deps
-/examples/*.o
-/tests/*.o
-/src/*.lo
-/src/*.o
-/src/*.la
-/src/.dirstamp
 /examples/trudp2p
 
 # Visual Studio user-specific files
@@ -68,6 +64,7 @@
 [Dd]ebug/
 [Rr]elease/
 x64/
+build-aux/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/src/packet.h
+++ b/src/packet.h
@@ -29,10 +29,11 @@
  * Created on May 30, 2016, 5:47 PM
  */
 
-#ifndef HEADER_H
-#define HEADER_H
+#ifndef PACKET_H
+#define PACKET_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #include "trudp_api.h"
 
@@ -112,4 +113,4 @@ size_t trudpPacketRESETlength();
 }
 #endif
 
-#endif /* HEADER_H */
+#endif /* PACKET_H */

--- a/src/packet_queue.h
+++ b/src/packet_queue.h
@@ -27,8 +27,8 @@
  * Created on May 30, 2016, 8:56 PM
  */
 
-#ifndef SEND_QUEUE_H
-#define SEND_QUEUE_H
+#ifndef PACKET_QUEUE_H
+#define PACKET_QUEUE_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -122,7 +122,7 @@ trudpPacketQueueData *trudpPacketQueueMoveToEnd(trudpPacketQueue *tq,
 trudpPacketQueueData *trudpPacketQueueFindById(trudpPacketQueue *tq, uint32_t id);
 trudpPacketQueueData *trudpPacketQueueGetFirst(trudpPacketQueue *tq);
 
-inline trudpPacket* trudpPacketQueueDataGetPacket(trudpPacketQueueData* tqd) {
+static inline trudpPacket* trudpPacketQueueDataGetPacket(trudpPacketQueueData* tqd) {
     return (trudpPacket*)(tqd->packet);
 }
 
@@ -130,4 +130,4 @@ inline trudpPacket* trudpPacketQueueDataGetPacket(trudpPacketQueueData* tqd) {
 }
 #endif
 
-#endif /* SEND_QUEUE_H */
+#endif /* PACKET_QUEUE_H */


### PR DESCRIPTION
- fixed invalid inclusion guards
- in std-c11 inline functions should have body defined in some compilation unit (and in only one, otherwise there be collisions)
  on the other hand - static inline functions do exactly what was intended - it's inlines in every callsite, haven't body in object library and doesn't cause multiple redefinition issues
- gitignores for build artifacts
