### PR TITLE
Get back "unused fields"

### DIFF
--- a/src/trudp_channel.c
+++ b/src/trudp_channel.c
@@ -113,6 +113,10 @@ static void _trudpChannelSetDefaults(trudpChannelData *tcd) {
   tcd->lastReceived = teoGetTimestampFull();
   tcd->lastSentPing = 0;  //  Never sent ping before
   tcd->triptimeMiddle = START_MIDDLE_TIME;
+  tcd->read_buffer = NULL;
+  tcd->read_buffer_ptr = 0;
+  tcd->read_buffer_size = 0;
+  tcd->last_packet_ptr = 0;
 
   // Initialize statistic
   trudpStatChannelInit(tcd);
@@ -127,6 +131,11 @@ static void _trudpChannelFree(trudpChannelData *tcd) {
 
   TD(tcd)->stat.sendQueue.size_current -= trudpSendQueueSize(tcd->sendQueue);
   TD(tcd)->stat.writeQueue.size_current -= trudpWriteQueueSize(tcd->writeQueue);
+
+  if (tcd->read_buffer != NULL) {
+    free(tcd->read_buffer);
+    tcd->read_buffer = NULL;
+  }
 
   trudpSendQueueFree(tcd->sendQueue);
   trudpWriteQueueFree(tcd->writeQueue);

--- a/src/trudp_channel.h
+++ b/src/trudp_channel.h
@@ -147,6 +147,13 @@ typedef struct trudpChannelData {
 
     int fd;                     ///< L0 client fd (emulation)
 
+
+    // Buffer for large packet from client
+    void *read_buffer;
+    size_t read_buffer_ptr;
+    size_t read_buffer_size;
+    size_t last_packet_ptr;
+
     // Cached channel unique string key
     char *channel_key;
     size_t channel_key_length;


### PR DESCRIPTION
it's used in teonet's l0-server module

Partial revert "Zero memory for new trudpChannelData. Remove unused fields."
This reverts commit 007d900d28d2fd55acaece61674a47377b69c8aa.