### PR TITLE
Fix TRUDP_API added to function definition

### DIFF
--- a/src/trudp_options.c
+++ b/src/trudp_options.c
@@ -6,13 +6,13 @@
 extern bool trudpOpt_DBG_sendto;
 bool trudpOpt_DBG_sendto = false;
 
-TRUDP_API void trudpSetOption_DBG_sendto(bool enable) {
+void trudpSetOption_DBG_sendto(bool enable) {
     trudpOpt_DBG_sendto = enable;
 }
 
 extern bool trudpOpt_DBG_dumpDataPacketHeaders;
 bool trudpOpt_DBG_dumpDataPacketHeaders = false;
 
-TRUDP_API void trudpSetOption_DBG_dumpDataPacketHeaders(bool enable) {
+void trudpSetOption_DBG_dumpDataPacketHeaders(bool enable) {
     trudpOpt_DBG_dumpDataPacketHeaders = enable;
 }


### PR DESCRIPTION
TRUDP_API macro should be added only to function declaration.