### PR TITLE
Fix lgtm 'Missing header guard' alert

### DIFF
--- a/src/trudp_ev.h
+++ b/src/trudp_ev.h
@@ -29,10 +29,10 @@
  * Created on July 27, 2016, 11:11 AM
  */
 
-#ifdef USE_LIBEV
-
 #ifndef TRUDP_EV_H
 #define TRUDP_EV_H
+
+#ifdef USE_LIBEV
 
 #include <ev.h>
 
@@ -62,6 +62,6 @@ TRUDP_API void trudpSendQueueCbStart(trudpProcessSendQueueData *psd,
 }
 #endif
 
-#endif /* TRUDP_EV_H */
-
 #endif
+
+#endif /* TRUDP_EV_H */


### PR DESCRIPTION
I fixed lgtm alert in file trudp_ev.h

It was not an error but rather the code that triggered an alert.