### PR TITLE
More type safety in function arguments

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -317,13 +317,13 @@ static void _trudpHeaderPINGcreate(trudpPacket* packet, uint32_t id,
 /**
  * Check TR-UDP packet (header)
  *
- * @param data Pointer to trudpHeader (to packet)
+ * @param data Pointer to buffer with received packet
  * @param packet_length Length of packet with trudp header
  *
  * @return Return true if packet is valid
  *
  */
-trudpPacket* trudpPacketCheck(void *data, size_t packet_length) {
+trudpPacket* trudpPacketCheck(uint8_t* data, size_t packet_length) {
   if (packet_length < sizeof(trudpHeader)) {
     return NULL;
   }
@@ -528,20 +528,6 @@ static inline void _trudpPacketSetChannel(trudpPacket *packet, int channel) {
 void *trudpPacketGetData(trudpPacket *packet) {
   return (char *)packet + sizeof(trudpHeader);
 }
-
-/**
- * Get pointer to packet from it's data
- *
- * @param data Pointer to packet data
- * @return Pointer to packet
- */
-// This is dangerous and should not be used.
-/*
-void *trudpPacketGetPacket(void *data) {
-
-  return (char *)data - sizeof(trudpHeader);
-}
-*/
 
 /**
  * Get packet data length

--- a/src/packet.h
+++ b/src/packet.h
@@ -84,8 +84,6 @@ typedef enum trudpPacketType {
 
 TRUDP_API uint32_t trudpGetTimestamp();
 TRUDP_API uint32_t trudpPacketGetId(trudpPacket *packet);
-// This is dangerous and should not be used.
-//TRUDP_API void *trudpPacketGetPacket(void *data);
 TRUDP_API trudpPacketType trudpPacketGetType(trudpPacket *packet);
 TRUDP_API size_t trudpPacketGetPacketLength(trudpPacket *packet);
 
@@ -94,7 +92,7 @@ trudpPacket* trudpPacketACKcreateNew(trudpPacket* packet);
 size_t trudpPacketACKlength();
 trudpPacket* trudpPacketACKtoPINGcreateNew(trudpPacket* packet);
 trudpPacket* trudpPacketACKtoRESETcreateNew(trudpPacket* packet);
-trudpPacket* trudpPacketCheck(void *data, size_t packet_length);
+trudpPacket* trudpPacketCheck(uint8_t* data, size_t packet_length);
 void trudpPacketCreatedFree(trudpPacket* packet);
 trudpPacket* trudpPacketDATAcreateNew(uint32_t id, unsigned int channel, void *data,
                                size_t data_length, size_t *packetLength);

--- a/src/trudp.c
+++ b/src/trudp.c
@@ -261,10 +261,10 @@ void trudpProcessReceived(trudpData* td, uint8_t* data, size_t data_length) {
 
     // Process received packet
     if(recvlen > 0) {
-        size_t data_length;
+        size_t packet_data_length;
 
         trudpChannelData *tcd = trudpGetChannelCreate(td, (__CONST_SOCKADDR_ARG) &remaddr, 0);
-        if(tcd == (void *)-1 || trudpChannelProcessReceivedPacket(tcd, data, recvlen, &data_length) == (void *)-1) {
+        if(tcd == (void *)-1 || trudpChannelProcessReceivedPacket(tcd, data, recvlen, &packet_data_length) == (void *)-1) {
             if(tcd == (void *)-1) {
                 printf("!!! can't PROCESS_RECEIVE_NO_TRUDP\n");
             } else {

--- a/src/trudp.h
+++ b/src/trudp.h
@@ -27,6 +27,9 @@
 #ifndef TR_UDP_H
 #define TR_UDP_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "teoccl/map.h"
 #include "packet_queue.h"
 #include "write_queue.h"
@@ -208,7 +211,6 @@ typedef struct trudpStatData {
  */
 typedef struct trudpData {
 
-    uint32_t trudp_data_label[2]; ///< Labele to distinguish trudpData and trudpChannelData
     teoMap *map; ///< Channels map (key: ip:port:channel)
     void* psq_data; ///< Send queue process data (used in external event loop)
     void* user_data; ///< User data
@@ -229,12 +231,14 @@ typedef struct trudpData {
 TRUDP_API trudpData *trudpInit(int fd, int port, trudpEventCb event_cb,
             void *user_data);
 TRUDP_API void trudpDestroy(trudpData* td);
-TRUDP_API void trudpSendEvent(void *t_pointer, int event, void *data,
+TRUDP_API void trudpSendEvent(trudpChannelData* tcd, int event, void *data,
+            size_t data_length, void *reserved);
+TRUDP_API void trudpSendGlobalEvent(trudpData* td, int event, void *data,
             size_t data_length, void *reserved);
 TRUDP_API trudpChannelData *trudpGetChannelCreate(trudpData *td,
             __CONST_SOCKADDR_ARG addr, int channel);
 TRUDP_API size_t trudpProcessKeepConnection(trudpData *td);
-TRUDP_API void trudpProcessReceived(trudpData *td, void *data, size_t data_length);
+TRUDP_API void trudpProcessReceived(trudpData* td, uint8_t* data, size_t data_length);
 TRUDP_API size_t trudpSendDataToAll(trudpData *td, void *data, size_t data_length);
 TRUDP_API void trudpSendResetAll(trudpData *td);
 TRUDP_API uint32_t trudpGetSendQueueTimeout(trudpData *td, uint64_t ts);
@@ -250,9 +254,9 @@ TRUDP_API void trudpChannelDestroyAll(trudpData *td);
 TRUDP_API trudpChannelData *trudpGetChannel(trudpData *td, __CONST_SOCKADDR_ARG addr,
         int channel);
 
-void *trudpSendEventGotData(void *t_pointer, trudpPacket *packet,
+void *trudpSendEventGotData(trudpChannelData* tcd, trudpPacket *packet,
           size_t *data_length);
-TRUDP_API int trudpIsPacketPing(void *data, size_t packet_length);
+TRUDP_API bool trudpIsPacketPing(uint8_t* data, size_t packet_length);
 
 const char * STRING_trudpEvent(trudpEvent val);
 

--- a/src/trudp_channel.c
+++ b/src/trudp_channel.c
@@ -613,7 +613,7 @@ size_t trudpChannelSendData(trudpChannelData *tcd, void *data,
  *         *data_length, if packet is not TR-UDP packet it's sent to client as
  * is
  */
-void *trudpChannelProcessReceivedPacket(trudpChannelData *tcd, void *data,
+void *trudpChannelProcessReceivedPacket(trudpChannelData *tcd, uint8_t *data,
                                         size_t packet_length,
                                         size_t *data_length) {
 

--- a/src/trudp_channel.h
+++ b/src/trudp_channel.h
@@ -180,7 +180,7 @@ TRUDP_API void trudpChannelSendRESET(trudpChannelData *tcd, void* data, size_t d
  */
 TRUDP_API void trudp_ChannelSendReset(trudpChannelData *tcd);
 
-TRUDP_API void *trudpChannelProcessReceivedPacket(trudpChannelData *tcd, void *data,
+TRUDP_API void *trudpChannelProcessReceivedPacket(trudpChannelData *tcd, uint8_t *data,
         size_t packet_length, size_t *data_length);
 size_t trudpChannelSendPING(trudpChannelData *tcd, void *data, size_t data_length);
 uint32_t trudpChannelSendQueueGetTimeout(trudpChannelData *tcd,

--- a/src/udp.c
+++ b/src/udp.c
@@ -32,11 +32,6 @@
 #include <string.h>
 #include <fcntl.h>
 
-// C11 present
-#if __STDC_VERSION__ >= 201112L
-//extern int inet_aton (const char *__cp, struct in_addr *__inp) __THROW;
-#endif
-
 #include "udp.h"
 #include "trudp_utils.h"
 #include "trudp_options.h"
@@ -215,16 +210,15 @@ int trudpUdpBindRaw(int *port, int allow_port_increment_f) {
 /**
  * Simple UDP recvfrom wrapper
  *
- * @param fd
- * @param buffer
- * @param buffer_size
- * @param remaddr
- * @param addr_length
- * @return
+ * @param fd Socket descriptor
+ * @param buffer Buffer to store received data
+ * @param buffer_size The size of buffer
+ * @param remaddr Remote address to receive from
+ * @param addr_length The length of @a remaddr argument
+ * @return The amount of bytes received or -1 on error
  */
-ssize_t trudpUdpRecvfrom(int fd, void *buffer, size_t buffer_size,
-        __SOCKADDR_ARG remaddr, socklen_t *addr_length) {
-
+ssize_t trudpUdpRecvfrom(int fd, uint8_t* buffer, size_t buffer_size,
+        __SOCKADDR_ARG remaddr, socklen_t* addr_length) {
     int flags = 0;
 
     // Read UDP data
@@ -288,26 +282,24 @@ static int _trudpUdpIsWritable(int sd, uint32_t timeOut) {
 /**
  * Simple UDP sendto wrapper
  *
- * @param fd File descriptor
- * @param buffer
- * @param buffer_size
- * @param remaddr
- * @param addrlen
- * @return
+ * @param fd Socket descriptor
+ * @param buffer Buffer with data to send
+ * @param buffer_size The size of data to send
+ * @param remaddr Address to send data to
+ * @param addrlen The length of @a remaddr argument
+ * @return The amount of bytes sent or -1 on error
  */
- ssize_t trudpUdpSendto(int fd, void *buffer, size_t buffer_size,
-        __CONST_SOCKADDR_ARG remaddr, socklen_t addrlen) {
-
+ ssize_t trudpUdpSendto(int fd, const uint8_t* buffer, size_t buffer_size,
+        __CONST_SOCKADDR_ARG remaddr, socklen_t addr_length) {
     CLTRACK(trudpOpt_DBG_sendto, "TrUdp", "Sending %u bytes using sendto().",
              (uint32_t)buffer_size);
-
     ssize_t sendlen = 0;
 
     //if(waitSocketWriteAvailable(fd, 1000000) > 0) {
 
     // Write UDP data
     int flags = 0;
-    sendlen = sendto(fd, buffer, buffer_size, flags, remaddr, addrlen);
+    sendlen = sendto(fd, buffer, buffer_size, flags, remaddr, addr_length);
     //}
 
     if (sendlen == -1) {

--- a/src/udp.h
+++ b/src/udp.h
@@ -41,16 +41,16 @@
     #include <ws2tcpip.h>
     typedef int socklen_t;
 
-    #define __SOCKADDR_ARG		struct sockaddr *__restrict
-    #define __CONST_SOCKADDR_ARG	const struct sockaddr *
+    #define __SOCKADDR_ARG struct sockaddr *__restrict
+    #define __CONST_SOCKADDR_ARG const struct sockaddr *
 
     #ifndef _SSIZE_T_DEFINED
     typedef intptr_t ssize_t;
     #define _SSIZE_T_DEFINED
     #endif
 #elif defined(__ANDROID__) || defined(__APPLE__)
-    #define __SOCKADDR_ARG		struct sockaddr *__restrict
-    #define __CONST_SOCKADDR_ARG	const struct sockaddr *
+    #define __SOCKADDR_ARG struct sockaddr *__restrict
+    #define __CONST_SOCKADDR_ARG const struct sockaddr *
     #include <netdb.h>
     #include <arpa/inet.h>
     #include <sys/socket.h>
@@ -66,13 +66,13 @@
 extern "C" {
 #endif
 
-TRUDP_API ssize_t trudpUdpSendto(int fd, void *buffer, size_t buffer_size,
-        __CONST_SOCKADDR_ARG remaddr, socklen_t addrlen);
+TRUDP_API ssize_t trudpUdpSendto(int fd, const uint8_t* buffer, size_t buffer_size,
+        __CONST_SOCKADDR_ARG remaddr, socklen_t addr_length);
 TRUDP_API int trudpUdpBindRaw(int *port, int allow_port_increment_f);
 TRUDP_API char *trudpUdpGetAddr(__CONST_SOCKADDR_ARG remaddr, int *port);
 
-TRUDP_API ssize_t trudpUdpRecvfrom(int fd, void *buffer, size_t buffer_size,
-        __SOCKADDR_ARG remaddr, socklen_t *addr_len);
+TRUDP_API ssize_t trudpUdpRecvfrom(int fd, uint8_t* buffer, size_t buffer_size,
+        __SOCKADDR_ARG remaddr, socklen_t *addr_length);
 TRUDP_API int trudpUdpMakeAddr(const char *addr, int port, __SOCKADDR_ARG remaddr,
         socklen_t *addr_len);
 


### PR DESCRIPTION
I changed code to be more type specific where possible.

Changes:
trudp.h
Field `uint32_t trudp_data_label[2]` no longer needed and removed from `trudpData`.

// trudpSendEvent now accepts `trudpChannelData* tcd` as first argument.
`TRUDP_API void trudpSendEvent(trudpChannelData* tcd, int event, void *data, size_t data_length, void *reserved);`
// Use trudpSendGlobalEvent for events with `trudpData* td` (INITIALIZE and DESTROY).
`TRUDP_API void trudpSendGlobalEvent(trudpData* td, int event, void *data, size_t data_length, void *reserved);`

// Buffer type is now `uint8_t* data`.
`TRUDP_API void trudpProcessReceived(trudpData* td, uint8_t* data, size_t data_length);`

// First argument now strongly typed as `trudpChannelData* tcd`.
`void *trudpSendEventGotData(trudpChannelData* tcd, trudpPacket *packet, size_t *data_length);`

// the return type is changed to bool and buffer type is `uint8_t* data`.
`TRUDP_API bool trudpIsPacketPing(uint8_t* data, size_t packet_length);`

trudp_channel.h
// Buffer type is now `uint8_t* buffer`
`TRUDP_API void *trudpChannelProcessReceivedPacket(trudpChannelData *tcd, uint8_t *data, size_t packet_length, size_t *data_length);`

packet.h
// Buffer type is now `uint8_t* data`.
`trudpPacket* trudpPacketCheck(uint8_t* data, size_t packet_length);`

udp.h
// Buffer type is now `const uint8_t* buffer`
`TRUDP_API ssize_t trudpUdpSendto(int fd, const uint8_t* buffer, size_t buffer_size, __CONST_SOCKADDR_ARG remaddr, socklen_t addr_length);`
		
// Buffer type is now `uint8_t* buffer`
`TRUDP_API ssize_t trudpUdpRecvfrom(int fd, uint8_t* buffer, size_t buffer_size, __SOCKADDR_ARG remaddr, socklen_t *addr_length);`

Fixed lgtm warning 'Declaration hides parameter' in `trudpProcessReceived`.

Also I fixed some inline documentation here and there.
