### PR TITLE
Rename event functions for better readability

### DIFF
--- a/examples/trudpcat_ev_wq.c
+++ b/examples/trudpcat_ev_wq.c
@@ -502,7 +502,7 @@ static trudpChannelData *connectToPeer(trudpData *td) {
  */
 static void host_cb(EV_P_ ev_io *w, int revents) {
 
-    trudpSendGlobalEvent(w->data, PROCESS_RECEIVE, buffer, o.buf_size, NULL);
+    trudpSendEvent(w->data, PROCESS_RECEIVE, buffer, o.buf_size, NULL);
 }
 
 /**

--- a/src/trudp.c
+++ b/src/trudp.c
@@ -87,7 +87,7 @@ trudpData *trudpInit(int fd, int port, trudpEventCb event_cb, void *user_data) {
     trudp->evendCb = event_cb;
 
     // Send INITIALIZE event
-    trudpSendGlobalEvent(trudp, INITIALIZE, NULL, 0, NULL);
+    trudpSendEvent(trudp, INITIALIZE, NULL, 0, NULL);
 
     return trudp;
 }
@@ -99,7 +99,7 @@ trudpData *trudpInit(int fd, int port, trudpEventCb event_cb, void *user_data) {
  */
 void trudpDestroy(trudpData* td) {
     if (td != NULL) {
-        trudpSendGlobalEvent(td, DESTROY, NULL, 0, NULL);
+        trudpSendEvent(td, DESTROY, NULL, 0, NULL);
         teoMapDestroy(td->map);
         free(td);
     }
@@ -114,7 +114,7 @@ void trudpDestroy(trudpData* td) {
  * @param data_length
  * @param reserved - reserved, not used
  */
-void trudpSendEvent(trudpChannelData* tcd, int event, void* data,
+void trudpChannelSendEvent(trudpChannelData* tcd, int event, void* data,
         size_t data_length, void* reserved) {
     trudpData *td = (trudpData*)tcd->td;
 
@@ -133,7 +133,7 @@ void trudpSendEvent(trudpChannelData* tcd, int event, void* data,
  * @param data_length
  * @param reserved - reserved, not used
  */
-void trudpSendGlobalEvent(trudpData* td, int event, void* data,
+void trudpSendEvent(trudpData* td, int event, void* data,
         size_t data_length, void* reserved) {
     trudpEventCb cb = td->evendCb;
     if (cb != NULL) {
@@ -147,9 +147,9 @@ void trudpSendGlobalEvent(trudpData* td, int event, void* data,
  * @param tcd Pointer to trudpChannelData
  * @param packet Pointer to received packet
  */
-void trudpSendEventGotData(trudpChannelData* tcd, trudpPacket *packet) {
+void trudpChannelSendEventGotData(trudpChannelData* tcd, trudpPacket *packet) {
     size_t data_len = trudpPacketGetDataLength(packet);
-    trudpSendEvent(tcd, GOT_DATA, packet, data_len, NULL);
+    trudpChannelSendEvent(tcd, GOT_DATA, packet, data_len, NULL);
 }
 
 /**
@@ -258,7 +258,7 @@ void trudpProcessReceived(trudpData* td, uint8_t* data, size_t data_length) {
             if(tcd == (void *)-1) {
                 printf("!!! can't PROCESS_RECEIVE_NO_TRUDP\n");
             } else {
-                trudpSendEvent(tcd, PROCESS_RECEIVE_NO_TRUDP, data, recvlen, NULL);
+                trudpChannelSendEvent(tcd, PROCESS_RECEIVE_NO_TRUDP, data, recvlen, NULL);
             }
         }
     }
@@ -428,7 +428,7 @@ trudpChannelData *trudpGetChannelCreate(trudpData *td, __CONST_SOCKADDR_ARG addr
     }
 
     if (tcd != (void*)-1 && !tcd->connected_f) {
-        trudpSendEvent(tcd, CONNECTED, NULL, 0, NULL);
+        trudpChannelSendEvent(tcd, CONNECTED, NULL, 0, NULL);
         tcd->connected_f = 1; // MUST BE AFTER EVENT!
     }
 

--- a/src/trudp.h
+++ b/src/trudp.h
@@ -231,9 +231,9 @@ typedef struct trudpData {
 TRUDP_API trudpData *trudpInit(int fd, int port, trudpEventCb event_cb,
             void *user_data);
 TRUDP_API void trudpDestroy(trudpData* td);
-TRUDP_API void trudpSendEvent(trudpChannelData* tcd, int event, void *data,
+TRUDP_API void trudpChannelSendEvent(trudpChannelData* tcd, int event, void *data,
             size_t data_length, void *reserved);
-TRUDP_API void trudpSendGlobalEvent(trudpData* td, int event, void *data,
+TRUDP_API void trudpSendEvent(trudpData* td, int event, void *data,
             size_t data_length, void *reserved);
 TRUDP_API trudpChannelData *trudpGetChannelCreate(trudpData *td,
             __CONST_SOCKADDR_ARG addr, int channel);
@@ -254,7 +254,7 @@ TRUDP_API void trudpChannelDestroyAll(trudpData *td);
 TRUDP_API trudpChannelData *trudpGetChannel(trudpData *td, __CONST_SOCKADDR_ARG addr,
         int channel);
 
-TRUDP_INTERNAL void trudpSendEventGotData(trudpChannelData *tcd, trudpPacket *packet);
+TRUDP_INTERNAL void trudpChannelSendEventGotData(trudpChannelData *tcd, trudpPacket *packet);
 TRUDP_API bool trudpIsPacketPing(uint8_t* data, size_t packet_length);
 
 const char * STRING_trudpEvent(trudpEvent val);


### PR DESCRIPTION
Some functions names are confusing.

I changed names to match common naming style in Trudp.
```
TRUDP_API void trudpSendEvent(trudpChannelData* tcd, int event, void *data, size_t data_length, void *reserved);
->
TRUDP_API void trudpChannelSendEvent(trudpChannelData* tcd, int event, void *data, size_t data_length, void *reserved);

TRUDP_API void trudpSendGlobalEvent(trudpData* td, int event, void *data, size_t data_length, void *reserved);
->
TRUDP_API void trudpSendEvent(trudpData* td, int event, void *data, size_t data_length, void *reserved);
```