### PR TITLE
Remove dangerous TD macro that is very easy to replace.

### DIFF
--- a/examples/trudp_pth.c
+++ b/examples/trudp_pth.c
@@ -245,9 +245,9 @@ static void event_cb(void *tcd_pointer, int event, void *data, size_t data_lengt
         // @param user_data NULL
         case PROCESS_SEND: {
 
-            //if(isWritable(TD(tcd)->fd, timeout) > 0) {
+            //if(isWritable(tcd->td->fd, timeout) > 0) {
             // Send to UDP
-            trudpUdpSendto(TD(tcd)->fd, data, data_length,
+            trudpUdpSendto(tcd->td->fd, data, data_length,
                     (__CONST_SOCKADDR_ARG) &tcd->remaddr, sizeof(tcd->remaddr));
             //}
 

--- a/examples/trudpcat.c
+++ b/examples/trudpcat.c
@@ -161,7 +161,7 @@ static void processDataCb(void *td_ptr, void *data, size_t data_length,
     }
     else {
         // Show statistic window
-        //showStatistic(TD(tcd));
+        //showStatistic(tcd->td);
     }
     debug("\n");
 }
@@ -196,9 +196,9 @@ static void sendPacketCb(void *tcd_ptr, void *packet, size_t packet_length,
 
     trudpChannelData *tcd = (trudpChannelData *)tcd_ptr;
 
-    //if(isWritable(TD(tcd)->fd, timeout) > 0) {   
+    //if(isWritable(tcd->td->fd, timeout) > 0) {   
     // Send to UDP
-    trudpUdpSendto(TD(tcd)->fd, packet, packet_length,
+    trudpUdpSendto(tcd->td->fd, packet, packet_length,
             (__CONST_SOCKADDR_ARG) &tcd->remaddr, sizeof(tcd->remaddr));
     //}
 

--- a/examples/trudpcat_ev.c
+++ b/examples/trudpcat_ev.c
@@ -405,7 +405,7 @@ static void eventCb(void *tcd_pointer, int event, void *data, size_t data_length
             }
             else {
                 // Show statistic window
-                //showStatistic(TD(tcd));
+                //showStatistic(tcd->td);
             }
             debug("\n");
 
@@ -429,9 +429,9 @@ static void eventCb(void *tcd_pointer, int event, void *data, size_t data_length
         // @param user_data NULL
         case PROCESS_SEND: {
 
-            //if(isWritable(TD(tcd)->fd, timeout) > 0) {
+            //if(isWritable(tcd->td->fd, timeout) > 0) {
             // Send to UDP
-            trudpUdpSendto(TD(tcd)->fd, data, data_length,
+            trudpUdpSendto(tcd->td->fd, data, data_length,
                     (__CONST_SOCKADDR_ARG) &tcd->remaddr, sizeof(tcd->remaddr));
             //}
 

--- a/examples/trudpcat_ev_wq.c
+++ b/examples/trudpcat_ev_wq.c
@@ -405,7 +405,7 @@ static void eventCb(void *tcd_pointer, int event, void *data, size_t data_length
             }
             else {
                 // Show statistic window
-                //showStatistic(TD(tcd));
+                //showStatistic(tcd->td);
             }
             debug("\n");
 
@@ -429,9 +429,9 @@ static void eventCb(void *tcd_pointer, int event, void *data, size_t data_length
         // @param user_data NULL
         case PROCESS_SEND: {
 
-            //if(isWritable(TD(tcd)->fd, timeout) > 0) {
+            //if(isWritable(tcd->td->fd, timeout) > 0) {
             // Send to UDP
-            trudpUdpSendto(TD(tcd)->fd, data, data_length,
+            trudpUdpSendto(tcd->td->fd, data, data_length,
                     (__CONST_SOCKADDR_ARG) &tcd->remaddr, sizeof(tcd->remaddr));
             //}
 

--- a/src/trudp.h
+++ b/src/trudp.h
@@ -45,12 +45,6 @@ extern "C" {
 #endif
 
 /**
- * Get pointer to trudpData from trudpChannelData
- */
-#define TD(tcd) ((trudpData*)tcd->td)
-#define TD_P(td) ((trudpData*)td)
-
-/**
  * Data received/send callback
  */
 typedef void (*trudpDataCb)(void *tcd, void *data, size_t data_length, void *user_data);

--- a/src/trudp_channel.c
+++ b/src/trudp_channel.c
@@ -134,8 +134,8 @@ static void _trudpChannelSetDefaults(trudpChannelData *tcd) {
  */
 static void _trudpChannelFree(trudpChannelData *tcd) {
 
-  TD(tcd)->stat.sendQueue.size_current -= trudpSendQueueSize(tcd->sendQueue);
-  TD(tcd)->stat.writeQueue.size_current -= trudpWriteQueueSize(tcd->writeQueue);
+  tcd->td->stat.sendQueue.size_current -= trudpSendQueueSize(tcd->sendQueue);
+  tcd->td->stat.writeQueue.size_current -= trudpWriteQueueSize(tcd->writeQueue);
 
   if (tcd->read_buffer != NULL) {
     free(tcd->read_buffer);
@@ -221,7 +221,7 @@ void trudpChannelDestroy(trudpChannelData *tcd) {
 
   char *channel_key = tcd->channel_key;
 
-  teoMapDelete(TD(tcd)->map, (uint8_t*)channel_key, tcd->channel_key_length);
+  teoMapDelete(tcd->td->map, (uint8_t*)channel_key, tcd->channel_key_length);
 
   free(channel_key);
 }
@@ -469,11 +469,11 @@ static uint64_t _trudpChannelCalculateExpectedTime(trudpChannelData *tcd,
  * @param tcd Pointer to trudpChannelData
  */
 static void _trudpChannelIncrementStatSendQueueSize(trudpChannelData *tcd) {
-  TD(tcd)->stat.sendQueue.size_current++;
+  tcd->td->stat.sendQueue.size_current++;
 }
 
 static void _trudpChannelIncrementStatWriteQueueSize(trudpChannelData *tcd) {
-  TD(tcd)->stat.writeQueue.size_current++;
+  tcd->td->stat.writeQueue.size_current++;
 }
 
 /**
@@ -519,7 +519,7 @@ static size_t _trudpChannelSendPacket(trudpChannelData *tcd,
         tcd->stat.packets_send++; // Send packets statistic
     }
     //    else if(save_to_send_queue)
-    //    trudp_start_send_queue_cb(TD(tcd)->psq_data, 0);
+    //    trudp_start_send_queue_cb(tcd->td->psq_data, 0);
 
     return packetLength;
 }
@@ -621,7 +621,7 @@ int trudpChannelProcessReceivedPacket(trudpChannelData *tcd, uint8_t *data,
         // Remove packet from send queue
         send_data_length = trudpPacketGetDataLength(sq_packet);
         trudpSendQueueDelete(tcd->sendQueue, sqd);
-        TD(tcd)->stat.sendQueue.size_current--;
+        tcd->td->stat.sendQueue.size_current--;
 
         if (trudpWriteQueueSize(tcd->writeQueue) > 0) {
           trudpWriteQueueData *wqd_first =
@@ -630,7 +630,7 @@ int trudpChannelProcessReceivedPacket(trudpChannelData *tcd, uint8_t *data,
                                   wqd_first->packet_length, 1);
           free(wqd_first->packet_ptr);
           trudpWriteQueueDeleteFirst(tcd->writeQueue);
-          TD(tcd)->stat.writeQueue.size_current--;
+          tcd->td->stat.writeQueue.size_current--;
         }
       }
 
@@ -862,7 +862,7 @@ int trudpChannelSendQueueProcess(trudpChannelData *tcd, uint64_t ts,
     //                (ts - tqd->retrieves_start) / 1000000.0);
     //            trudpExecEventCallback(tcd, DISCONNECTED, key, strlen(key) +
     //            1,
-    //                TD(tcd)->user_data, TD(tcd)->evendCb);
+    //                tcd->td->user_data, tcd->td->evendCb);
     //
     //            trudpDestroyChannel(tcd);
     //

--- a/tests/main_t.c
+++ b/tests/main_t.c
@@ -523,7 +523,7 @@ CHEAT_TEST(trudp_send_process_received_packet,
         cheat_assert(send_result > 0);
     }
 
-    char *stat_str = ksnTRUDPstatShowStr(TD(tcd_A), 0);
+    char *stat_str = ksnTRUDPstatShowStr(tcd_A->td, 0);
     puts(stat_str);
     free(stat_str);
 


### PR DESCRIPTION
This macro contain explicit pointer cast so it will cast anything to trudpData without compilation error or warning.

After merging #55 it's now easu as replace TD(tcd)->fd with tcd->td->fd.